### PR TITLE
Enable example for iOS 5

### DIFF
--- a/Example/MSNavigationPaneViewController Example.xcodeproj/project.pbxproj
+++ b/Example/MSNavigationPaneViewController Example.xcodeproj/project.pbxproj
@@ -349,6 +349,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MSNavigationPaneViewController/MSNavigationPaneViewController Example-Prefix.pch";
 				INFOPLIST_FILE = "MSNavigationPaneViewController/MSNavigationPaneViewController Example-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = MSNPVC;
 				WRAPPER_EXTENSION = app;
 			};
@@ -360,6 +361,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MSNavigationPaneViewController/MSNavigationPaneViewController Example-Prefix.pch";
 				INFOPLIST_FILE = "MSNavigationPaneViewController/MSNavigationPaneViewController Example-Info.plist";
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = MSNPVC;
 				WRAPPER_EXTENSION = app;
 			};

--- a/Example/MSNavigationPaneViewController/MSMasterViewController.m
+++ b/Example/MSNavigationPaneViewController/MSMasterViewController.m
@@ -84,7 +84,6 @@ typedef NS_ENUM(NSUInteger, MSMasterViewControllerTableViewSectionType) {
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    [self.tableView registerClass:UITableViewCell.class forCellReuseIdentifier:MSMasterViewControllerCellReuseIdentifier];
 }
 
 #pragma mark - MSMasterViewController
@@ -159,7 +158,10 @@ typedef NS_ENUM(NSUInteger, MSMasterViewControllerTableViewSectionType) {
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
 {
-    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:MSMasterViewControllerCellReuseIdentifier forIndexPath:indexPath];
+    UITableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:MSMasterViewControllerCellReuseIdentifier];
+    if (cell == nil) {
+        cell = [[UITableViewCell alloc] initWithStyle:UITableViewCellStyleDefault reuseIdentifier:MSMasterViewControllerCellReuseIdentifier];
+    }
     cell.textLabel.text = self.paneViewControllerTitles[@([self paneViewControllerTypeForIndexPath:indexPath])];
     return cell;
 }


### PR DESCRIPTION
Example was iOS 6 only and crashed if enabled for iOS 5
