### PR TITLE
Add UITableViewCell.class to touchForwardingClasses in order to allow reorderable table views?

### DIFF
--- a/MSNavigationPaneViewController/MSDraggableView.m
+++ b/MSNavigationPaneViewController/MSDraggableView.m
@@ -101,7 +101,7 @@ typedef void (^ViewActionBlock)(UIView *view);
         self.animating = NO;
         self.xVelocity = 0.0;
         
-        _touchForwardingClasses = [NSMutableSet setWithObjects:UISlider.class, UISwitch.class, nil];
+        _touchForwardingClasses = [NSMutableSet setWithObjects:UISlider.class, UISwitch.class, UITableViewCell.class, nil];
         
         self.panGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(panned:)];
         _panGestureRecognizer.minimumNumberOfTouches = 1;


### PR DESCRIPTION
If one uses a reorderable UITableView, then the pan gesture on
MSDraggableView prevents the UITableViewCellReorderControl from
working. I have added UITableViewCell to the list of
touchForwardingClasses. (The UITableViewCellReorderControl itself
is a private class, so we have to use UITableViewCell.)
