### PR TITLE
Tap gesture recognizer not removed and blocking taps to paneViewController

### DIFF
--- a/MSNavigationPaneViewController/MSNavigationPaneViewController.m
+++ b/MSNavigationPaneViewController/MSNavigationPaneViewController.m
@@ -571,9 +571,11 @@ typedef void (^ViewActionBlock)(UIView *view);
         
         void(^animatePaneOpenCompletion)(BOOL animationFinished) = ^(BOOL animationFinished) {
             internalCompletion();
-            self.paneTapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(paneTapped:)];
-            self.paneTapGestureRecognizer.numberOfTouchesRequired = 1;
-            self.paneTapGestureRecognizer.numberOfTapsRequired = 1;
+            if (!self.paneTapGestureRecognizer) {
+                self.paneTapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(paneTapped:)];
+                self.paneTapGestureRecognizer.numberOfTouchesRequired = 1;
+                self.paneTapGestureRecognizer.numberOfTapsRequired = 1;
+            }
             [self.paneView addGestureRecognizer:self.paneTapGestureRecognizer];
         };
         


### PR DESCRIPTION
I had the bug that there were sometimes two or more UITapGestureRecognizers added to the paneViewController, but only one was removed when the paneViewController was closed (i.e. covering the full screen). 

It happened both when I set the `paneState` to open just after initialization in the app delegate or if the user hits the home button during a close animation. My close animation was sometimes long, on an iPad, revealWidth almost screen width, and in landscape.

One solution is to not create a new paneTapGestureRecognizer object every time the pane is opened, like below and in my pull request. Alternatively, the `self.paneTapGestureRecognizer` property could be completely removed and when the pane is closed loop through the gesture recognizers on `self.paneView` and remove every tap gesture. 

`
if (!self.paneTapGestureRecognizer) {
    self.paneTapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(paneTapped:)];
    self.paneTapGestureRecognizer.numberOfTouchesRequired = 1;
    self.paneTapGestureRecognizer.numberOfTapsRequired = 1;
    }
    [self.paneView addGestureRecognizer:self.paneTapGestureRecognizer];
`
