### PR TITLE
Pull request - optional willUpdateToPaneState: method added to delegate protocol

### DIFF
--- a/MSNavigationPaneViewController/MSNavigationPaneViewController.h
+++ b/MSNavigationPaneViewController/MSNavigationPaneViewController.h
@@ -88,5 +88,6 @@ typedef NS_ENUM(NSUInteger, MSNavigationPaneAppearanceType) {
 - (void)navigationPaneViewController:(MSNavigationPaneViewController *)navigationPaneViewController willAnimateToPane:(UIViewController *)paneViewController;
 - (void)navigationPaneViewController:(MSNavigationPaneViewController *)navigationPaneViewController didAnimateToPane:(UIViewController *)paneViewController;
 - (void)navigationPaneViewController:(MSNavigationPaneViewController *)navigationPaneViewController didUpdateToPaneState:(MSNavigationPaneState)state;
+- (void)navigationPaneViewController:(MSNavigationPaneViewController *)navigationPaneViewController willUpdateToPaneState:(MSNavigationPaneState)state;
 
 @end

--- a/MSNavigationPaneViewController/MSNavigationPaneViewController.m
+++ b/MSNavigationPaneViewController/MSNavigationPaneViewController.m
@@ -436,6 +436,12 @@ typedef void (^ViewActionBlock)(UIView *view);
 
 - (void)animatePaneToState:(MSNavigationPaneState)state duration:(CGFloat)duration bounce:(BOOL)bounce
 {
+
+     // Notify delegate of pane state change
+    if ([self.delegate respondsToSelector:@selector(navigationPaneViewController:willUpdateToPaneState:)]) {
+        [self.delegate navigationPaneViewController:self willUpdateToPaneState:state];
+    }
+
     CGFloat startPosition;
     switch (self.openDirection) {
         case MSNavigationPaneOpenDirectionLeft:


### PR DESCRIPTION
Hi, Eric:

Thanks for the fix you pushed recently.  I also added this optional method to the delegate protocol, found it useful for my app in making sure that the data source that feeds my side menu was up to date.  Feel free to incorporate or not as you see fit.

Thanks!

Added optional delegate method to MSNavigationPaneViewControllerDelegate protocol:
- (void)navigationPaneViewController:(MSNavigationPaneViewController *)navigationPaneViewController willUpdateToPaneState:(MSNavigationPaneState)state;

Notifies the delegate that the user has asked for a pane state change.  Passes the MSNavigationPaneState that has been requested.
