### PR TITLE
Add methods to bounce pane view with a completion block.

### DIFF
--- a/Example/Example/MSBounceViewController.m
+++ b/Example/Example/MSBounceViewController.m
@@ -194,7 +194,7 @@ typedef NS_ENUM(NSInteger, MSBounceSectionType) {
     __block NSInteger possibleDrawerDirectionRow = 0;
     MSDynamicsDrawerDirectionActionForMaskedValues(dynamicsDrawerViewController.possibleDrawerDirection, ^(MSDynamicsDrawerDirection drawerDirection) {
         if (indexPath.row == possibleDrawerDirectionRow) {
-            [dynamicsDrawerViewController bouncePaneOpenInDirection:drawerDirection];
+            [dynamicsDrawerViewController bouncePaneOpenInDirection:drawerDirection allowUserInterruption:NO completion:nil];
             [self.tableView deselectRowAtIndexPath:indexPath animated:YES];
         }
         possibleDrawerDirectionRow++;

--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.h
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.h
@@ -192,22 +192,11 @@ typedef NS_ENUM(NSInteger, MSDynamicsDrawerPaneState) {
 - (void)setPaneState:(MSDynamicsDrawerPaneState)paneState inDirection:(MSDynamicsDrawerDirection)direction animated:(BOOL)animated allowUserInterruption:(BOOL)allowUserInterruption completion:(void (^)(void))completion;
 
 /**
- Bounces the `paneView` open to reveal the `drawerView` underneath.
- 
- If there is more than one drawer view controller set, use `bouncePaneOpenInDirection:`. When invoked, `bounceElasticity` and `bounceMagnitude` are used as the dynamics values for the `paneView`.
- 
- @see bouncePaneOpenInDirection:
- @see bouncePaneOpenInDirection:completion:
- @see bounceElasticity
- @see bounceMagnitude
- */
-- (void)bouncePaneOpen;
-
-/**
  Bounces the `paneView` open to reveal the `drawerView` underneath. Executes `completion` when the dynamic animation finishes.
  
- If there is more than one drawer view controller set, use `bouncePaneOpenInDirection:`. When invoked, `bounceElasticity` and `bounceMagnitude` are used as the dynamics values for the `paneView`.
+ If there is more than one drawer view controller set, use `bouncePaneOpenInDirection:allowUserInterruption:completion:`. When invoked, `bounceElasticity` and `bounceMagnitude` are used as the dynamics values for the `paneView`.
  
+ @param allowUserInterruption If the user should be able to interrupt the bounce animation with gestures.
  @param completion A block that is run when the dynamic animator finishes animating the bounce.
  ?
  @see bouncePaneOpenInDirection:
@@ -215,28 +204,15 @@ typedef NS_ENUM(NSInteger, MSDynamicsDrawerPaneState) {
  @see bounceElasticity
  @see bounceMagnitude
  */
-- (void)bouncePaneOpenWithCompletion:(void (^)(void))completion;
-
-/**
- Bounces the `paneView` open in the specified direction, revealing the `drawerView` underneath.
- 
- If there is only one drawer view controller, use `bouncePaneOpen` instead. When invoked, `bounceElasticity` and `bounceMagnitude` are used as the dynamics values for the `paneView`.
- 
- @param direction The direction that the `paneView` will be bounced open in.
-  ?
- @see bouncePaneOpenInDirection:completion:
- @see bouncePaneOpen
- @see bounceElasticity
- @see bounceMagnitude
- */
-- (void)bouncePaneOpenInDirection:(MSDynamicsDrawerDirection)direction;
+- (void)bouncePaneOpenAllowUserInterruption:(BOOL)allowUserInterruption completion:(void (^)(void))completion;
 
 /**
  Bounces the `paneView` open in the specified direction, revealing the `drawerView` underneath. Executes `completion` when the dynamic animation finishes.
  
- If there is only one drawer view controller, use `bouncePaneOpenWithCompletion:` instead. When invoked, `bounceElasticity` and `bounceMagnitude` are used as the dynamics values for the `paneView`.
+ If there is only one drawer view controller, use `bouncePaneOpenAllowUserInterruption:completion:` instead. When invoked, `bounceElasticity` and `bounceMagnitude` are used as the dynamics values for the `paneView`.
  
  @param direction The direction that the `paneView` will be bounced open in.
+ @param allowUserInterruption If the user should be able to interrupt the bounce animation with gestures.
  @param completion A block that is run when the dynamic animator finishes animating the bounce.
  ?
  @see bouncePaneOpenInDirection:
@@ -244,7 +220,7 @@ typedef NS_ENUM(NSInteger, MSDynamicsDrawerPaneState) {
  @see bounceElasticity
  @see bounceMagnitude
  */
-- (void)bouncePaneOpenInDirection:(MSDynamicsDrawerDirection)direction completion:(void (^)(void))completion;
+- (void)bouncePaneOpenInDirection:(MSDynamicsDrawerDirection)direction allowUserInterruption:(BOOL)allowUserInterruption completion:(void (^)(void))completion;
 
 /**
  The directions that the `paneView` can be opened in.

--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.h
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.h
@@ -192,6 +192,19 @@ typedef NS_ENUM(NSInteger, MSDynamicsDrawerPaneState) {
 - (void)setPaneState:(MSDynamicsDrawerPaneState)paneState inDirection:(MSDynamicsDrawerDirection)direction animated:(BOOL)animated allowUserInterruption:(BOOL)allowUserInterruption completion:(void (^)(void))completion;
 
 /**
+ Bounces the `paneView` open to reveal the `drawerView` underneath.
+ 
+ If there is more than one drawer view controller set, use `bouncePaneOpenInDirection:`. When invoked, `bounceElasticity` and `bounceMagnitude` are used as the dynamics values for the `paneView`. The bounce can be interrupted by a user touch. To override this behavior, use `bouncePaneOpenAllowUserInterruption:completion:`
+ ?
+ @see bouncePaneOpenInDirection:
+ @see bouncePaneOpenAllowUserInterruption:completion:
+ @see bouncePaneOpenInDirection:allowUserInterruption:completion:
+ @see bounceElasticity
+ @see bounceMagnitude
+ */
+- (void)bouncePaneOpen;
+
+/**
  Bounces the `paneView` open to reveal the `drawerView` underneath. Executes `completion` when the dynamic animation finishes.
  
  If there is more than one drawer view controller set, use `bouncePaneOpenInDirection:allowUserInterruption:completion:`. When invoked, `bounceElasticity` and `bounceMagnitude` are used as the dynamics values for the `paneView`.
@@ -199,12 +212,28 @@ typedef NS_ENUM(NSInteger, MSDynamicsDrawerPaneState) {
  @param allowUserInterruption If the user should be able to interrupt the bounce animation with gestures.
  @param completion A block that is run when the dynamic animator finishes animating the bounce.
  ?
+ @see bouncePaneOpen
  @see bouncePaneOpenInDirection:
- @see bouncePaneOpenInDirection:completion:
+ @see bouncePaneOpenInDirection:allowUserInterruption:completion:
  @see bounceElasticity
  @see bounceMagnitude
  */
 - (void)bouncePaneOpenAllowUserInterruption:(BOOL)allowUserInterruption completion:(void (^)(void))completion;
+
+/**
+ Bounces the `paneView` open in the specified direction, revealing the `drawerView` underneath.
+ 
+ If there is only one drawer view controller, use `bouncePaneOpen` instead. When invoked, `bounceElasticity` and `bounceMagnitude` are used as the dynamics values for the `paneView`.
+ 
+ @param direction The direction that the `paneView` will be bounced open in.
+ ?
+ @see bouncePaneOpen
+ @see bouncePaneOpenAllowUserInterruption:completion:
+ @ese bouncePaneOpenInDirection:allowUserInterruption:completion:
+ @see bounceElasticity
+ @see bounceMagnitude
+ */
+- (void)bouncePaneOpenInDirection:(MSDynamicsDrawerDirection)direction;
 
 /**
  Bounces the `paneView` open in the specified direction, revealing the `drawerView` underneath. Executes `completion` when the dynamic animation finishes.
@@ -215,8 +244,9 @@ typedef NS_ENUM(NSInteger, MSDynamicsDrawerPaneState) {
  @param allowUserInterruption If the user should be able to interrupt the bounce animation with gestures.
  @param completion A block that is run when the dynamic animator finishes animating the bounce.
  ?
- @see bouncePaneOpenInDirection:
  @see bouncePaneOpen
+ @see bouncePaneOpenAllowUserInterruption:completion:
+ @see bouncePaneOpenInDirection:
  @see bounceElasticity
  @see bounceMagnitude
  */

--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.h
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.h
@@ -197,10 +197,25 @@ typedef NS_ENUM(NSInteger, MSDynamicsDrawerPaneState) {
  If there is more than one drawer view controller set, use `bouncePaneOpenInDirection:`. When invoked, `bounceElasticity` and `bounceMagnitude` are used as the dynamics values for the `paneView`.
  
  @see bouncePaneOpenInDirection:
+ @see bouncePaneOpenInDirection:completion:
  @see bounceElasticity
  @see bounceMagnitude
  */
 - (void)bouncePaneOpen;
+
+/**
+ Bounces the `paneView` open to reveal the `drawerView` underneath. Executes `completion` when the dynamic animation finishes.
+ 
+ If there is more than one drawer view controller set, use `bouncePaneOpenInDirection:`. When invoked, `bounceElasticity` and `bounceMagnitude` are used as the dynamics values for the `paneView`.
+ 
+ @param completion A block that is run when the dynamic animator finishes animating the bounce.
+ ?
+ @see bouncePaneOpenInDirection:
+ @see bouncePaneOpenInDirection:completion:
+ @see bounceElasticity
+ @see bounceMagnitude
+ */
+- (void)bouncePaneOpenWithCompletion:(void (^)(void))completion;
 
 /**
  Bounces the `paneView` open in the specified direction, revealing the `drawerView` underneath.
@@ -209,11 +224,27 @@ typedef NS_ENUM(NSInteger, MSDynamicsDrawerPaneState) {
  
  @param direction The direction that the `paneView` will be bounced open in.
   ?
+ @see bouncePaneOpenInDirection:completion:
  @see bouncePaneOpen
  @see bounceElasticity
  @see bounceMagnitude
  */
 - (void)bouncePaneOpenInDirection:(MSDynamicsDrawerDirection)direction;
+
+/**
+ Bounces the `paneView` open in the specified direction, revealing the `drawerView` underneath. Executes `completion` when the dynamic animation finishes.
+ 
+ If there is only one drawer view controller, use `bouncePaneOpenWithCompletion:` instead. When invoked, `bounceElasticity` and `bounceMagnitude` are used as the dynamics values for the `paneView`.
+ 
+ @param direction The direction that the `paneView` will be bounced open in.
+ @param completion A block that is run when the dynamic animator finishes animating the bounce.
+ ?
+ @see bouncePaneOpenInDirection:
+ @see bouncePaneOpen
+ @see bounceElasticity
+ @see bounceMagnitude
+ */
+- (void)bouncePaneOpenInDirection:(MSDynamicsDrawerDirection)direction completion:(void (^)(void))completion;
 
 /**
  The directions that the `paneView` can be opened in.

--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
@@ -294,14 +294,27 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(MSDynamicsDrawerDirection di
 
 - (void)bouncePaneOpen
 {
+    [self bouncePaneOpenWithCompletion:nil];
+}
+
+- (void)bouncePaneOpenWithCompletion:(void (^)(void))completion
+{
     NSAssert(MSDynamicsDrawerDirectionIsCardinal(self.possibleDrawerDirection), @"Unable to bounce open with multiple possible reveal directions");
-    [self bouncePaneOpenInDirection:self.currentDrawerDirection];
+    [self bouncePaneOpenInDirection:self.currentDrawerDirection completion:completion];
 }
 
 - (void)bouncePaneOpenInDirection:(MSDynamicsDrawerDirection)direction
 {
+    [self bouncePaneOpenInDirection:direction completion:nil];
+}
+
+- (void)bouncePaneOpenInDirection:(MSDynamicsDrawerDirection)direction completion:(void (^)(void))completion
+{
     NSAssert(((self.possibleDrawerDirection & direction) == direction), @"Unable to bounce open with impossible/multiple directions");
     self.currentDrawerDirection = direction;
+    if (completion) {
+        self.dynamicAnimatorCompletion = completion;
+    }
     [self addDynamicsBehaviorsToCreatePaneState:MSDynamicsDrawerPaneStateClosed pushMagnitude:self.bounceMagnitude pushAngle:[self gravityAngleForState:MSDynamicsDrawerPaneStateOpen direction:direction] pushElasticity:self.bounceElasticity];
 }
 

--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
@@ -292,10 +292,20 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(MSDynamicsDrawerDirection di
 
 #pragma mark Bouncing
 
+- (void)bouncePaneOpen
+{
+    [self bouncePaneOpenAllowUserInterruption:YES completion:nil];
+}
+
 - (void)bouncePaneOpenAllowUserInterruption:(BOOL)allowInterrupt completion:(void (^)(void))completion
 {
     NSAssert(MSDynamicsDrawerDirectionIsCardinal(self.possibleDrawerDirection), @"Unable to bounce open with multiple possible reveal directions");
     [self bouncePaneOpenInDirection:self.currentDrawerDirection allowUserInterruption:allowInterrupt completion:completion];
+}
+
+- (void)bouncePaneOpenInDirection:(MSDynamicsDrawerDirection)direction
+{
+    [self bouncePaneOpenInDirection:direction allowUserInterruption:YES completion:nil];
 }
 
 - (void)bouncePaneOpenInDirection:(MSDynamicsDrawerDirection)direction allowUserInterruption:(BOOL)allowInterrupt completion:(void (^)(void))completion


### PR DESCRIPTION
Sometimes it's necessary to perform actions when a bounce is completed. Since the animation is dynamic, it's not appropriate to accomplish this with timers.

Please review the approach I took hooking into the dynamic animator completion block. I think it is right, but I do not fully understand the possible internal states this object may have.
