### PR TITLE
Option to accept pans only originating near an edge, to simulate iOS 7's edge swipes.

### DIFF
--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.h
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.h
@@ -259,6 +259,13 @@ typedef NS_ENUM(NSInteger, MSDynamicsDrawerPaneState) {
  */
 @property (nonatomic, assign, readonly) MSDynamicsDrawerDirection possibleDrawerDirection;
 
+/**
+ Whether only pans from the edges should be accepted to slide open drawers. If set to YES, pans originating in the center of the screen will not be processed.
+
+ Defaults to NO.
+ */
+@property (nonatomic, assign) BOOL acceptsEdgePanOnly;
+
 ///-------------------------------------
 /// @name Configuring Dynamics Behaviors
 ///-------------------------------------

--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
@@ -37,6 +37,7 @@ const CGFloat MSDynamicsDrawerDefaultOpenStateRevealWidthVertical = 300.0;
 const CGFloat MSDynamicsDrawerOpenAnimationOvershot = 30.0;
 const CGFloat MSPaneViewVelocityThreshold = 5.0;
 const CGFloat MSPaneViewVelocityMultiplier = 5.0;
+const CGFloat MKPaneViewEdgeSwipeThreshold = 30.0;
 
 NSString * const MSDynamicsDrawerBoundaryIdentifier = @"MSDynamicsDrawerBoundaryIdentifier";
 
@@ -1115,6 +1116,37 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(MSDynamicsDrawerDirection di
 }
 
 #pragma mark - UIGestureRecognizerDelegate
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+{
+	if (self.acceptsEdgePanOnly && (gestureRecognizer == self.panePanGestureRecognizer)) {
+		CGPoint location = [gestureRecognizer locationInView:self.paneView];
+		CGPoint velocity = [self.panePanGestureRecognizer velocityInView:self.paneView];
+		BOOL horizontal = fabs(velocity.x) > fabs(velocity.y);
+		UIEdgeInsets distanceToEdges = UIEdgeInsetsMake(location.y,
+														location.x,
+														self.paneView.bounds.size.height - location.y,
+														self.paneView.bounds.size.width - location.x);
+		if (horizontal) {
+			if (distanceToEdges.left < MKPaneViewEdgeSwipeThreshold && velocity.x > 0) {
+				return YES;
+			}
+			else if (distanceToEdges.right < MKPaneViewEdgeSwipeThreshold && velocity.x < 0) {
+				return YES;
+			}
+		}
+		else {
+			if (distanceToEdges.top < MKPaneViewEdgeSwipeThreshold && velocity.y > 0) {
+				return YES;
+			}
+			else if (distanceToEdges.bottom < MKPaneViewEdgeSwipeThreshold && velocity.y < 0) {
+				return YES;
+			}
+		}
+		return NO;
+	}
+	return YES;
+}
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch
 {


### PR DESCRIPTION
Make the drawer feel more iOS 7-y by opening it only with an edge swipe-type gesture. Works for all edges. The threshold worked in my testing, but can easily be changed. Defaults to NO, to preserve the original behavior.
