### PR TITLE
Fix crash deallocating a drawer view controller that was never loaded.

### DIFF
--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
@@ -157,7 +157,9 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(MSDynamicsDrawerDirection di
 
 - (void)dealloc
 {
-    [self.paneView removeObserver:self forKeyPath:@"frame"];
+    if (self.isViewLoaded) {
+        [self.paneView removeObserver:self forKeyPath:@"frame"];
+    }
 }
 
 #pragma mark - UIViewController

--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
@@ -129,7 +129,7 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(MSDynamicsDrawerDirection di
 @property (nonatomic, strong) NSMutableSet *touchForwardingClasses;
 @property (nonatomic, strong) UIPanGestureRecognizer *panePanGestureRecognizer;
 @property (nonatomic, strong) UITapGestureRecognizer *paneTapGestureRecognizer;
-// Dyanimcs
+// Dynamics
 @property (nonatomic, strong) UIDynamicAnimator *dynamicAnimator;
 @property (nonatomic, strong) UIPushBehavior *panePushBehavior;
 @property (nonatomic, strong) UIDynamicItemBehavior *paneElasticityBehavior;
@@ -157,12 +157,7 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(MSDynamicsDrawerDirection di
 
 - (void)dealloc
 {
-    @try {
-        [self.paneView removeObserver:self forKeyPath:NSStringFromSelector(@selector(frame))];
-    }
-    @catch (NSException __unused *exception) {
-        
-    }
+    [self.paneView removeObserver:self forKeyPath:NSStringFromSelector(@selector(frame))];
 }
 
 #pragma mark - UIViewController
@@ -183,7 +178,6 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(MSDynamicsDrawerDirection di
     self.drawerView.frame = (CGRect){CGPointZero, self.view.frame.size};
     self.paneView.frame = (CGRect){CGPointZero, self.view.frame.size};
     self.view.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
-    [self.paneView addObserver:self forKeyPath:@"frame" options:0 context:NULL];
     
     self.dynamicAnimator = [[UIDynamicAnimator alloc] initWithReferenceView:self.view];
     self.dynamicAnimator.delegate = self;
@@ -261,6 +255,7 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(MSDynamicsDrawerDirection di
     self.drawerView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     
     self.paneView = [UIView new];
+    [self.paneView addObserver:self forKeyPath:@"frame" options:0 context:NULL];
     self.paneView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     
     self.panePanGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(panePanned:)];

--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
@@ -157,8 +157,11 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(MSDynamicsDrawerDirection di
 
 - (void)dealloc
 {
-    if (self.isViewLoaded) {
-        [self.paneView removeObserver:self forKeyPath:@"frame"];
+    @try {
+        [self.paneView removeObserver:self forKeyPath:NSStringFromSelector(@selector(frame))];
+    }
+    @catch (NSException __unused *exception) {
+        
     }
 }
 

--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
@@ -255,7 +255,7 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(MSDynamicsDrawerDirection di
     self.drawerView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     
     self.paneView = [UIView new];
-    [self.paneView addObserver:self forKeyPath:@"frame" options:0 context:NULL];
+    [self.paneView addObserver:self forKeyPath:NSStringFromSelector(@selector(frame)) options:0 context:NULL];
     self.paneView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);
     
     self.panePanGestureRecognizer = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(panePanned:)];


### PR DESCRIPTION
Remove key value observation only if the view is loaded, because view loading is where we establish frame observing.
This fix is important for unit tests where the application UI may partially load: instantiating classes and relationships but not view hierarchies.
