### PR TITLE
Redraw shadow styler after rotation

### DIFF
--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerStyler.m
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerStyler.m
@@ -243,6 +243,8 @@
 
 @property (nonatomic, strong) CALayer *shadowLayer;
 
+- (void) rotationChanged;
+
 @end
 
 @implementation MSDynamicsDrawerShadowStyler
@@ -257,8 +259,23 @@
         self.shadowRadius = 10.0;
 		self.shadowOpacity = 1.0;
         self.shadowOffset = CGSizeZero;
+        
+        [[NSNotificationCenter defaultCenter] addObserver:self
+                                                 selector:@selector(rotationChanged)
+                                                     name:UIApplicationDidChangeStatusBarOrientationNotification
+                                                   object:nil];
     }
     return self;
+}
+
+- (void)dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
+
+- (void)rotationChanged
+{
+    [self.shadowLayer removeFromSuperlayer];
 }
 
 #pragma mark - MSDynamicsDrawerStyler
@@ -279,8 +296,8 @@
 }
 
 - (void)dynamicsDrawerViewController:(MSDynamicsDrawerViewController *)dynamicsDrawerViewController didUpdatePaneClosedFraction:(CGFloat)paneClosedFraction forDirection:(MSDynamicsDrawerDirection)direction
-{
-    if (direction & MSDynamicsDrawerDirectionAll) {
+{    
+    if (direction != MSDynamicsDrawerDirectionNone) {
         if (!self.shadowLayer.superlayer) {
             CGRect shadowRect = (CGRect){CGPointZero, dynamicsDrawerViewController.paneView.frame.size};
             if (direction & MSDynamicsDrawerDirectionHorizontal) {


### PR DESCRIPTION
I've been having trouble with the shadow styler getting into a messy state if the device rotates with a drawer open, particularly on iPad rotating from landscape to portrait. The shadow often ends up as an opaque mass covering most of my view.

This change removes the shadow before rotation and replaces it afterwards.

Thanks for a great pod!
