### PR TITLE
Cleaning up self.self

### DIFF
--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
@@ -496,7 +496,7 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(MSDynamicsDrawerDirection di
     
     if (elasticity != 0.0) {
         self.paneElasticityBehavior.elasticity = elasticity;
-        [self.dynamicAnimator addBehavior:self.self.paneElasticityBehavior];
+        [self.dynamicAnimator addBehavior:self.paneElasticityBehavior];
     }
     
     if (pushMagnitude != 0.0) {


### PR DESCRIPTION
No reason to reference `self.self.`
