### PR TITLE
Allwo any 3rd party control to work on MSDynamics

### DIFF
--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
@@ -247,7 +247,7 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(MSDynamicsDrawerDirection di
     self.paneTapToCloseEnabled = [NSMutableDictionary new];
     self.stylers = [NSMutableDictionary new];
     
-    self.touchForwardingClasses = [NSMutableSet setWithArray:@[[UISlider class], [UISwitch class]]];
+    self.touchForwardingClasses = [NSMutableSet setWithArray:@[[UISlider class], [UISwitch class], [UIControl class]]];
     
     self.drawerView = [UIView new];
     self.drawerView.autoresizingMask = (UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight);


### PR DESCRIPTION
Adding UIControl in touchForwardingClasses will make all 3rd party controls work properly without losing touch events.
