### PR TITLE
Fix: dynamicAnimatorCompletion block not called

### DIFF
--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
@@ -1374,20 +1374,23 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(NSInteger direction, MSDynam
 - (void)dynamicAnimatorDidPause:(UIDynamicAnimator *)animator
 {
     // If the dynaimc animator has paused while the `panePanGestureRecognizer` is active, ignore it as it's a side effect of removing behaviors, not a resting state
-    if (self.panePanGestureRecognizer.state != UIGestureRecognizerStatePossible) return;
+    if (self.panePanGestureRecognizer.state == UIGestureRecognizerStatePossible) {
+        
+        // Since a resting pane state has been reached, we can remove all behaviors
+        [self.dynamicAnimator removeAllBehaviors];
+        
+        // Update the pane state to the nearest pane state
+        [self _setPaneState:[self nearestPaneState]];
+        
+        // Update pane user interaction appropriately
+        [self setPaneViewControllerViewUserInteractionEnabled:(self.paneState == MSDynamicsDrawerPaneStateClosed)];
+        
+        // Since rotation is disabled while the dynamic animator is running, we invoke this method to cause rotation to happen (if device rotation has occured during state transition)
+        [UIViewController attemptRotationToDeviceOrientation];
+        
+    }
     
-    // Since a resting pane state has been reached, we can remove all behaviors
-    [self.dynamicAnimator removeAllBehaviors];
-    
-    // Update the pane state to the nearest pane state
-    [self _setPaneState:[self nearestPaneState]];
-    
-    // Update pane user interaction appropriately
-    [self setPaneViewControllerViewUserInteractionEnabled:(self.paneState == MSDynamicsDrawerPaneStateClosed)];
-    
-    // Since rotation is disabled while the dynamic animator is running, we invoke this method to cause rotation to happen (if device rotation has occured during state transition)
-    [UIViewController attemptRotationToDeviceOrientation];
-    
+    // Always call the completion block
     if (self.dynamicAnimatorCompletion) {
         self.dynamicAnimatorCompletion();
         self.dynamicAnimatorCompletion = nil;


### PR DESCRIPTION
I got some weird issues with my app because `viewDidAppear` was not called sometimes.
Then I saw that the `dynamicAnimatorCompletion` block was not called from:
`- (void)setPaneViewController:(UIViewController *)paneViewController animated:(BOOL)animated completion:(void (^)(void))completion` at line 419.
There is a `[self setPaneState:MSDynamicsDrawerPaneStateClosed animated:animated allowUserInterruption:YES completion:^{` at line 449 that ultimately calls `didMoveToParentViewController`, a really important method for children viewControllers to have.
It turns out that when the central pane appears and you move quickly a `collectionView` or move the central pane, the completionBlock is not called causing a lot of troubles with `navigationController`. I fixed that by calling the block anyway when gesture state is not `UIGestureRecognizerStatePossible`.

Anyway, this fixes a lot of issues I had and I hope it can help others too :) Love this drawer! :+1:
