### PR TITLE
Fixed typo. Prevent crash when dismissing modal view.

### DIFF
--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
@@ -149,7 +149,7 @@
 
 - (void)viewDidDisappear:(BOOL)animated
 {
-    [super viewWillAppear:animated];
+    [super viewDidDisappear:animated];
     if (!self.view.window) {
         [self _stylesWillMoveToDrawerViewController:nil];
         [self.paneView removeObserver:self forKeyPath:NSStringFromSelector(@selector(center))];


### PR DESCRIPTION
Just a little mistake, pretty harmless in usual situations but in my case it was causing MFMailComposeViewController to crash on dismiss.
