### PR TITLE
Fixed re-ordering for UITableView on iOS8

### DIFF
--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
@@ -1362,8 +1362,10 @@ void MSDynamicsDrawerDirectionActionForMaskedValues(NSInteger direction, MSDynam
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
-    // If the other gesture recognizer's view is a `UITableViewCell` instance's internal `UIScrollView`, require failure
-    if ([[otherGestureRecognizer.view nextResponder] isKindOfClass:[UITableViewCell class]] && [otherGestureRecognizer.view isKindOfClass:[UIScrollView class]]) {
+    // On iOS7: If the other gesture recognizer's view is a `UITableViewCell` instance's internal `UIScrollView`, require failure
+    // On iOS8: If the other gesture recognizer's view is a `UITableViewWrapperView` instance's internal `UITableView`, require failure
+    if (([[otherGestureRecognizer.view nextResponder] isKindOfClass:[UITableViewCell class]] && [otherGestureRecognizer.view isKindOfClass:[UIScrollView class]]) ||
+        ([[otherGestureRecognizer.view nextResponder] isKindOfClass:[UITableView class]] && [NSStringFromClass([otherGestureRecognizer.view class]) isEqualToString:@"UITableViewWrapperView"])) {
         return YES;
     }
     return NO;


### PR DESCRIPTION
I downloaded this great library and implement it to my project yesterday, everything works fine but one little bug.

If I want to re-order my UITableViewCell, it works on iOS7, but fails on iOS8. The cell isn't draggable.
After couple google's, I found that the issue comes from the view hierarchy has changed on iOS8, leads to 

```
- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
```

fail to determine the correct class.

otherGestureRecognizer's view's nextResponder should be `UITableView` on iOS8 
and otherGestureRecognizer's view should be `UITableViewWrapperView`

Tested and works fine, hope I'm right!
Thank you
