### PR TITLE
Fix for unbalanced appearance method call

### DIFF
--- a/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
+++ b/MSDynamicsDrawerViewController/MSDynamicsDrawerViewController.m
@@ -149,7 +149,7 @@
 
 - (void)viewDidDisappear:(BOOL)animated
 {
-    [super viewWillAppear:animated];
+    [super viewDidDisappear:animated];
     if (!self.view.window) {
         [self _stylesWillMoveToDrawerViewController:nil];
         [self.paneView removeObserver:self forKeyPath:NSStringFromSelector(@selector(center))];


### PR DESCRIPTION
Causing crash while trying to remove observer under some conditions.
