### PR TITLE
Fix the "Example" app (the non-storyboard target), which appears broken when built using the iOS 9 SDK.

### DIFF
--- a/Example/Example/MSAppDelegate.m
+++ b/Example/Example/MSAppDelegate.m
@@ -55,7 +55,7 @@
     [self.dynamicsDrawerViewController addStylersFromArray:@[[MSDynamicsDrawerParallaxStyler styler]] forDirection:MSDynamicsDrawerDirectionRight];
     
 #if !defined(STORYBOARD)
-    MSMenuViewController *menuViewController = [MSMenuViewController new];
+    MSMenuViewController *menuViewController = [[MSMenuViewController alloc] initWithNibName:nil bundle:nil];
 #else
     MSMenuViewController *menuViewController = [self.window.rootViewController.storyboard instantiateViewControllerWithIdentifier:@"Menu"];
 #endif

--- a/Example/Example/MSMenuViewController.m
+++ b/Example/Example/MSMenuViewController.m
@@ -189,7 +189,7 @@ typedef NS_ENUM(NSUInteger, MSMenuViewControllerTableViewSectionType) {
     UIViewController *paneViewController = [self.storyboard instantiateViewControllerWithIdentifier:self.paneViewControllerIdentifiers[@(paneViewControllerType)]];
 #else
     Class paneViewControllerClass = self.paneViewControllerClasses[@(paneViewControllerType)];
-    UIViewController *paneViewController = (UIViewController *)[paneViewControllerClass new];
+    UIViewController *paneViewController = (UIViewController *)[[paneViewControllerClass alloc] initWithNibName:nil bundle:nil];
 #endif
     
     paneViewController.navigationItem.title = self.paneViewControllerTitles[@(paneViewControllerType)];


### PR DESCRIPTION
Potential fix for https://github.com/erichoracek/MSDynamicsDrawerViewController/issues/167.
