### PR TITLE
Make MSDynamicsDrawerViewController Carthage Compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ DerivedData
 
 # Documentation
 docs/docset-installed.txt
+
+# Carthage
+*.framework.zip

--- a/Docs/Docs.xcodeproj/project.pbxproj
+++ b/Docs/Docs.xcodeproj/project.pbxproj
@@ -20,6 +20,13 @@
 		};
 /* End PBXAggregateTarget section */
 
+/* Begin PBXBuildFile section */
+		94B491981EDA821A003A74A4 /* MSDynamicsDrawerViewControllerFramework.h in Headers */ = {isa = PBXBuildFile; fileRef = 94B491961EDA821A003A74A4 /* MSDynamicsDrawerViewControllerFramework.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94B4919C1EDA8247003A74A4 /* MSDynamicsDrawerStyler.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A935DE718F1F719004F464D /* MSDynamicsDrawerStyler.m */; };
+		94B4919D1EDA824B003A74A4 /* MSDynamicsDrawerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A935DE918F1F719004F464D /* MSDynamicsDrawerViewController.m */; };
+		94B4919E1EDA829D003A74A4 /* MSDynamicsDrawerStyler.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A935DE618F1F719004F464D /* MSDynamicsDrawerStyler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+/* End PBXBuildFile section */
+
 /* Begin PBXFileReference section */
 		3A935DE618F1F719004F464D /* MSDynamicsDrawerStyler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSDynamicsDrawerStyler.h; sourceTree = "<group>"; };
 		3A935DE718F1F719004F464D /* MSDynamicsDrawerStyler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSDynamicsDrawerStyler.m; sourceTree = "<group>"; };
@@ -28,13 +35,27 @@
 		3AAD490E1830929B003FAFA8 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		3AAD491C1830929B003FAFA8 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		3AAD491F1830929B003FAFA8 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		94B491941EDA821A003A74A4 /* MSDynamicsDrawerViewControllerFramework.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MSDynamicsDrawerViewControllerFramework.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		94B491961EDA821A003A74A4 /* MSDynamicsDrawerViewControllerFramework.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MSDynamicsDrawerViewControllerFramework.h; sourceTree = "<group>"; };
+		94B491971EDA821A003A74A4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		94B491901EDA821A003A74A4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
 		3AAD49021830929B003FAFA8 = {
 			isa = PBXGroup;
 			children = (
 				3AAD49101830929B003FAFA8 /* MSDynamicsDrawerViewController */,
+				94B491951EDA821A003A74A4 /* MSDynamicsDrawerViewControllerFramework */,
 				3AAD490D1830929B003FAFA8 /* Frameworks */,
 				3AAD490C1830929B003FAFA8 /* Products */,
 			);
@@ -43,6 +64,7 @@
 		3AAD490C1830929B003FAFA8 /* Products */ = {
 			isa = PBXGroup;
 			children = (
+				94B491941EDA821A003A74A4 /* MSDynamicsDrawerViewControllerFramework.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -69,7 +91,57 @@
 			path = ../MSDynamicsDrawerViewController;
 			sourceTree = SOURCE_ROOT;
 		};
+		94B491951EDA821A003A74A4 /* MSDynamicsDrawerViewControllerFramework */ = {
+			isa = PBXGroup;
+			children = (
+				94B491961EDA821A003A74A4 /* MSDynamicsDrawerViewControllerFramework.h */,
+				94B4919B1EDA8230003A74A4 /* Supporting Files */,
+			);
+			path = MSDynamicsDrawerViewControllerFramework;
+			sourceTree = "<group>";
+		};
+		94B4919B1EDA8230003A74A4 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				94B491971EDA821A003A74A4 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		94B491911EDA821A003A74A4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				94B4919E1EDA829D003A74A4 /* MSDynamicsDrawerStyler.h in Headers */,
+				94B491981EDA821A003A74A4 /* MSDynamicsDrawerViewControllerFramework.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
+/* Begin PBXNativeTarget section */
+		94B491931EDA821A003A74A4 /* MSDynamicsDrawerViewControllerFramework */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 94B4919A1EDA821A003A74A4 /* Build configuration list for PBXNativeTarget "MSDynamicsDrawerViewControllerFramework" */;
+			buildPhases = (
+				94B4918F1EDA821A003A74A4 /* Sources */,
+				94B491901EDA821A003A74A4 /* Frameworks */,
+				94B491911EDA821A003A74A4 /* Headers */,
+				94B491921EDA821A003A74A4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = MSDynamicsDrawerViewControllerFramework;
+			productName = MSDynamicsDrawerViewControllerFramework;
+			productReference = 94B491941EDA821A003A74A4 /* MSDynamicsDrawerViewControllerFramework.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+/* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		3AAD49031830929B003FAFA8 /* Project object */ = {
@@ -77,6 +149,12 @@
 			attributes = {
 				LastUpgradeCheck = 0510;
 				ORGANIZATIONNAME = "Monospace Ltd";
+				TargetAttributes = {
+					94B491931EDA821A003A74A4 = {
+						CreatedOnToolsVersion = 8.3.2;
+						ProvisioningStyle = Automatic;
+					};
+				};
 			};
 			buildConfigurationList = 3AAD49061830929B003FAFA8 /* Build configuration list for PBXProject "Docs" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -91,9 +169,20 @@
 			projectRoot = "";
 			targets = (
 				3AAD493A183094D3003FAFA8 /* Docs */,
+				94B491931EDA821A003A74A4 /* MSDynamicsDrawerViewControllerFramework */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		94B491921EDA821A003A74A4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
 		3AAD493E183094E1003FAFA8 /* Documentation */ = {
@@ -112,6 +201,18 @@
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		94B4918F1EDA821A003A74A4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				94B4919D1EDA824B003A74A4 /* MSDynamicsDrawerViewController.m in Sources */,
+				94B4919C1EDA8247003A74A4 /* MSDynamicsDrawerStyler.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
 
 /* Begin XCBuildConfiguration section */
 		3AAD492D1830929B003FAFA8 /* Release */ = {
@@ -152,6 +253,41 @@
 			};
 			name = Release;
 		};
+		94B491991EDA821A003A74A4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = MSDynamicsDrawerViewControllerFramework/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.MSDynamicsDrawerViewControllerFramework;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -170,6 +306,13 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		94B4919A1EDA821A003A74A4 /* Build configuration list for PBXNativeTarget "MSDynamicsDrawerViewControllerFramework" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				94B491991EDA821A003A74A4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Docs/Docs.xcodeproj/project.pbxproj
+++ b/Docs/Docs.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		94B4919C1EDA8247003A74A4 /* MSDynamicsDrawerStyler.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A935DE718F1F719004F464D /* MSDynamicsDrawerStyler.m */; };
 		94B4919D1EDA824B003A74A4 /* MSDynamicsDrawerViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 3A935DE918F1F719004F464D /* MSDynamicsDrawerViewController.m */; };
 		94B4919E1EDA829D003A74A4 /* MSDynamicsDrawerStyler.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A935DE618F1F719004F464D /* MSDynamicsDrawerStyler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		94B491A11EDA878D003A74A4 /* MSDynamicsDrawerViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 3A935DE818F1F719004F464D /* MSDynamicsDrawerViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -116,6 +117,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				94B4919E1EDA829D003A74A4 /* MSDynamicsDrawerStyler.h in Headers */,
+				94B491A11EDA878D003A74A4 /* MSDynamicsDrawerViewController.h in Headers */,
 				94B491981EDA821A003A74A4 /* MSDynamicsDrawerViewControllerFramework.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Docs/Docs.xcodeproj/xcshareddata/xcschemes/MSDynamicsDrawerViewControllerFramework.xcscheme
+++ b/Docs/Docs.xcodeproj/xcshareddata/xcschemes/MSDynamicsDrawerViewControllerFramework.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0830"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "94B491931EDA821A003A74A4"
+               BuildableName = "MSDynamicsDrawerViewControllerFramework.framework"
+               BlueprintName = "MSDynamicsDrawerViewControllerFramework"
+               ReferencedContainer = "container:Docs.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Release"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "94B491931EDA821A003A74A4"
+            BuildableName = "MSDynamicsDrawerViewControllerFramework.framework"
+            BlueprintName = "MSDynamicsDrawerViewControllerFramework"
+            ReferencedContainer = "container:Docs.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "94B491931EDA821A003A74A4"
+            BuildableName = "MSDynamicsDrawerViewControllerFramework.framework"
+            BlueprintName = "MSDynamicsDrawerViewControllerFramework"
+            ReferencedContainer = "container:Docs.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Release">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Docs/MSDynamicsDrawerViewControllerFramework/Info.plist
+++ b/Docs/MSDynamicsDrawerViewControllerFramework/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.5.2</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Docs/MSDynamicsDrawerViewControllerFramework/MSDynamicsDrawerViewControllerFramework.h
+++ b/Docs/MSDynamicsDrawerViewControllerFramework/MSDynamicsDrawerViewControllerFramework.h
@@ -1,0 +1,12 @@
+#import <UIKit/UIKit.h>
+
+//! Project version number for MSDynamicsDrawerViewControllerFramework.
+FOUNDATION_EXPORT double MSDynamicsDrawerViewControllerFrameworkVersionNumber;
+
+//! Project version string for MSDynamicsDrawerViewControllerFramework.
+FOUNDATION_EXPORT const unsigned char MSDynamicsDrawerViewControllerFrameworkVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <MSDynamicsDrawerViewControllerFramework/PublicHeader.h>
+
+<MSDynamicsDrawerViewControllerFramework/MSDynamicsDrawerStyler.h>
+<MSDynamicsDrawerViewControllerFramework/MSDynamicsDrawerViewController.h>

--- a/Docs/MSDynamicsDrawerViewControllerFramework/MSDynamicsDrawerViewControllerFramework.h
+++ b/Docs/MSDynamicsDrawerViewControllerFramework/MSDynamicsDrawerViewControllerFramework.h
@@ -8,5 +8,5 @@ FOUNDATION_EXPORT const unsigned char MSDynamicsDrawerViewControllerFrameworkVer
 
 // In this header, you should import all the public headers of your framework using statements like #import <MSDynamicsDrawerViewControllerFramework/PublicHeader.h>
 
-<MSDynamicsDrawerViewControllerFramework/MSDynamicsDrawerStyler.h>
-<MSDynamicsDrawerViewControllerFramework/MSDynamicsDrawerViewController.h>
+#import <MSDynamicsDrawerViewControllerFramework/MSDynamicsDrawerStyler.h>
+#import <MSDynamicsDrawerViewControllerFramework/MSDynamicsDrawerViewController.h>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Introduction
+# Introduction [![Carthage Compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)
 
 **MSDynamicsDrawerViewController** was written by **[Eric Horacek](https://twitter.com/erichoracek)** for **[Monospace Ltd.](http://www.monospacecollective.com)**
 


### PR DESCRIPTION
In order to make this project Carthage compatible, a Cocoa Touch (dynamically linked) framework target was added.  This mean that the lowest version of iOS supported will be iOS 8.0 for consumers of this framework.

I would also like to note that I've set the version of this framework in this pull request to `1.5.2`.  This can be changed based on your release schedule, but be aware that in order for users to be able to consume this framework once this PR is merged, a git tag will need to be created that should match the version of the framework target.